### PR TITLE
Fix NDDataRef mask propagation bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -292,6 +292,12 @@ astropy.modeling
 - Fixed an issue with Parameter where a getter could be input without a
   setter (or vice versa). [#14708]
 
+astropy.nddata
+^^^^^^^^^^^^^^
+
+- Fixed mask propagation in ``NDDataRef`` arithmetic when only one operand
+  has a mask. [#14995]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -520,7 +520,8 @@ class NDArithmeticMixin:
         elif self.mask is None and operand is not None:
             # Make a copy so there is no reference in the result.
             return deepcopy(operand.mask)
-        elif operand is None:
+        elif operand is None or operand.mask is None:
+            # Only self has a mask, so return a copy of it.
             return deepcopy(self.mask)
         else:
             # Now lets calculate the resulting mask (operation enforces copy)


### PR DESCRIPTION
## Summary
- handle case where only one operand has a mask in `NDArithmeticMixin`
- document fix in change log

## Testing
- `pytest -k nddata -vv` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68516a80fb38832a937c94f78c9ab915